### PR TITLE
Set name option to double dash `--`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker pull vromero/mule
 For a simple application using 8081 port as HTTP
 
 ```
-docker run -d -name myMuleInstance -P -v ~/myAppsDir:/opt/mule/apps -v ~/myLogsDir:/opt/mule/logs vromero/mule
+docker run -d --name myMuleInstance -P -v ~/myAppsDir:/opt/mule/apps -v ~/myLogsDir:/opt/mule/logs vromero/mule
 ```
 
 #### Noteworthy mount points


### PR DESCRIPTION
Per `docker run --help`

```
--name string    Assign a name to the container
```
